### PR TITLE
Fix `cargo vendor` for anki (csv-core: change version to 0.0.99)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ bench = false
 
 [dependencies]
 bstr = { version = "0.2.1", features = ["serde1"] }
-csv-core = { path = "csv-core", version = "0.1.6" }
+csv-core = { path = "csv-core", version = "0.0.99" }
 itoa = "1"
 ryu = "1"
 serde = "1.0.55"

--- a/csv-core/Cargo.toml
+++ b/csv-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "csv-core"
-version = "0.1.10"  #:version
+version = "0.0.99"  #:version changed to allow vendoring anki
 authors = ["Andrew Gallant <jamslam@gmail.com>"]
 description = "Bare bones CSV parsing with no_std support."
 documentation = "https://docs.rs/csv-core"


### PR DESCRIPTION
cargo vendor on anki currently fails as follow:
```
error: failed to sync

Caused by:
  found duplicate version of package `csv-core v0.1.10` vendored from two sources:

        source 1: registry `crates-io`
        source 2: https://github.com/ankitects/rust-csv.git?rev=1c9d3aab6f79a7d815c69f925a46a4590c115f90#1c9d3aab
```

Because csv-core is included twice in the dependency tree:
```
├── csv v1.1.6 (https://github.com/ankitects/rust-csv.git?rev=1c9d3aab6f79a7d815c69f925a46a4590c115f90#1c9d3aab)
│   ├── csv-core v0.1.10 (https://github.com/ankitects/rust-csv.git?rev=1c9d3aab6f79a7d815c69f925a46a4590c115f90#1c9d3aab)
├── fsrs-optimizer v0.1.0 (https://github.com/open-spaced-repetition/fsrs-optimizer-rs?rev=e0b15cce555a94de6fdaa4bf1e096d19704a397d#e0b15cce)
│   ├── burn v0.9.0 (https://github.com/burn-rs/burn.git?rev=36446e8d35694a9158f97e85e44b84544b8c4afb#36446e8d)
│   │   ├── burn-core v0.9.0 (https://github.com/burn-rs/burn.git?rev=36446e8d35694a9158f97e85e44b84544b8c4afb#36446e8d)
│   │   │   ├── burn-dataset v0.9.0 (https://github.com/burn-rs/burn.git?rev=36446e8d35694a9158f97e85e44b84544b8c4afb#36446e8d)
│   │   │   │   ├── csv v1.2.2
│   │   │   │   │   ├── csv-core v0.1.10
```

Until something similar to commit 1c9d3aab6f79 ("Automatically escape
fields that contain the comment character") makes it in an upstream
release, take the easy way out and just make sure the versions don't
conflict for cargo vendor.


(I've got a patch for upstream as well that'll just allow adding arbitrary characters to `requires_quotes` for an eventual v0.1.11 or v0.2, but would like to get anki to build on nixos first -- since nixos requires bundling cargo dependencies with something akin to cargo vendor this is a hard requirement for us.

I've confirmed anki builds with the following patch on top of 23.10beta1
```diff
diff --git a/Cargo.lock b/Cargo.lock
index d4369100bee4..c4d849beda5c 100644
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1094,10 +1094,10 @@ dependencies = [
 [[package]]
 name = "csv"
 version = "1.1.6"
-source = "git+https://github.com/ankitects/rust-csv.git?rev=1c9d3aab6f79a7d815c69f925a46a4590c115f90#1c9d3aab6f79a7d815c69f925a46a4590c115f90"
+source = "git+https://github.com/ankitects/rust-csv.git?rev=74721cd1e0f6d1b4dca4967d606fef0148a94d53#74721cd1e0f6d1b4dca4967d606fef0148a94d53"
 dependencies = [
  "bstr 0.2.17",
- "csv-core 0.1.10 (git+https://github.com/ankitects/rust-csv.git?rev=1c9d3aab6f79a7d815c69f925a46a4590c115f90)",
+ "csv-core 0.0.99",
  "itoa",
  "ryu",
  "serde",
@@ -1109,7 +1109,7 @@ version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "626ae34994d3d8d668f4269922248239db4ae42d538b14c398b74a52208e8086"
 dependencies = [
- "csv-core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "csv-core 0.1.10",
  "itoa",
  "ryu",
  "serde",
@@ -1117,9 +1117,8 @@ dependencies = [
 
 [[package]]
 name = "csv-core"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+version = "0.0.99"
+source = "git+https://github.com/ankitects/rust-csv.git?rev=74721cd1e0f6d1b4dca4967d606fef0148a94d53#74721cd1e0f6d1b4dca4967d606fef0148a94d53"
 dependencies = [
  "memchr",
 ]
@@ -1127,7 +1126,8 @@ dependencies = [
 [[package]]
 name = "csv-core"
 version = "0.1.10"
-source = "git+https://github.com/ankitects/rust-csv.git?rev=1c9d3aab6f79a7d815c69f925a46a4590c115f90#1c9d3aab6f79a7d815c69f925a46a4590c115f90"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
 dependencies = [
  "memchr",
 ]
diff --git a/Cargo.toml b/Cargo.toml
index 96a3eb83988c..97503158543a 100644
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ resolver = "2"
 
 [workspace.dependencies.csv]
 git = "https://github.com/ankitects/rust-csv.git"
-rev = "1c9d3aab6f79a7d815c69f925a46a4590c115f90"
+rev = "74721cd1e0f6d1b4dca4967d606fef0148a94d53"
 
 [workspace.dependencies.percent-encoding-iri]
 git = "https://github.com/ankitects/rust-url.git"

```

Thanks!